### PR TITLE
Add web search module

### DIFF
--- a/modules/interpreter.py
+++ b/modules/interpreter.py
@@ -19,6 +19,10 @@ def compute_match_score(text, keywords, objects):
 def extract_numbers(text):
     return list(map(int, re.findall(r"\b\d+\b", text)))
 
+def extract_search_query(text):
+    match = re.search(r"(?:search|google|look(?:\s*up)?|find)(?:\s+for)?\s+(.*)", text)
+    return match.group(1).strip() if match else text.strip()
+
 # === INTENT REGISTRY ===
 registered_intents = {
     "launch_drone": {
@@ -62,6 +66,11 @@ registered_intents = {
                 event_bus.emit("EMIT_MODULE_READ", {"filename": f"core/{match.group(1)}.py" if match.group(1) in {"event_bus", "dispatcher", "peterjones"} else f"modules/{match.group(1)}.py"})
             ) if (match := re.match(r"read module (\w+)", text)) else None
         )(text)
+    },
+    "web_search": {
+        "keywords": ["search", "google", "look", "find"],
+        "objects": ["web", "internet"],
+        "handler": lambda text: event_bus.emit("EMIT_WEB_SEARCH", {"query": extract_search_query(text)})
     },
 }
 

--- a/modules/web_search.py
+++ b/modules/web_search.py
@@ -1,0 +1,59 @@
+import requests
+import datetime
+import os
+from core.event_bus import event_bus
+
+LOG_PATH = '/home/triad/mitch/logs/web_search.log'
+SEARCH_API = 'https://api.duckduckgo.com/'
+
+
+def log(message: str) -> None:
+    ts = datetime.datetime.utcnow().isoformat()
+    os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
+    with open(LOG_PATH, 'a', encoding='utf-8') as f:
+        f.write(f"{ts} {message}\n")
+
+
+def fetch_results(query: str) -> str:
+    try:
+        resp = requests.get(
+            SEARCH_API,
+            params={'q': query, 'format': 'json', 'no_redirect': '1', 'no_html': '1'},
+            timeout=5,
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            results = []
+            for item in data.get('RelatedTopics', [])[:3]:
+                if isinstance(item, dict):
+                    if 'Text' in item:
+                        results.append(item['Text'])
+                    elif 'Topics' in item:
+                        for sub in item['Topics']:
+                            if 'Text' in sub:
+                                results.append(sub['Text'])
+                            if len(results) >= 3:
+                                break
+                if len(results) >= 3:
+                    break
+            if not results and data.get('AbstractText'):
+                results.append(data['AbstractText'])
+            return ' | '.join(results) if results else 'No results.'
+        return f"Search API error {resp.status_code}."
+    except Exception as e:
+        return f"Search failed: {e}"
+
+
+def handle_web_search(event):
+    query = event.get('query', '').strip()
+    if not query:
+        return
+    log(f"Query: {query}")
+    summary = fetch_results(query)
+    log(f"Summary: {summary}")
+    event_bus.emit('EMIT_WEB_SEARCH_RESULT', {'query': query, 'summary': summary})
+
+
+def start_module(event_bus):
+    log('Web search module started')
+    event_bus.subscribe('EMIT_WEB_SEARCH', handle_web_search)


### PR DESCRIPTION
## Summary
- add a web_search module to query DuckDuckGo and log results
- introduce `web_search` intent in interpreter to trigger EMIT_WEB_SEARCH

## Testing
- `python -m py_compile modules/web_search.py modules/interpreter.py`

------
https://chatgpt.com/codex/tasks/task_e_6842006d1c70832391da05d18ce138ea