### PR TITLE
Use configurable MITCH_ROOT path

### DIFF
--- a/audit_mitch.py
+++ b/audit_mitch.py
@@ -1,8 +1,9 @@
 import os
 import ast
 import json
+from core.config import MITCH_ROOT
 
-PROJECT_ROOT = "/home/triad/mitch"
+PROJECT_ROOT = MITCH_ROOT
 SUMMARY_FILE = "mitch_audit_report.txt"
 EVENTS_JSON = "mitch_event_map.json"
 

--- a/core/config.py
+++ b/core/config.py
@@ -1,0 +1,4 @@
+import os
+from pathlib import Path
+
+MITCH_ROOT = os.getenv("MITCH_ROOT", Path(__file__).resolve().parents[1])

--- a/core/event_bus.py
+++ b/core/event_bus.py
@@ -4,9 +4,10 @@ from datetime import datetime
 import inspect
 import os
 import requests
+from core.config import MITCH_ROOT
 
 DEBUG = os.getenv("MITCH_DEBUG", "false").lower() == "true"
-INNERMONO_PATH = "/home/triad/mitch/logs/innermono.log"
+INNERMONO_PATH = os.path.join(MITCH_ROOT, "logs", "innermono.log")
 
 class EventBus:
     _instance = None

--- a/core/event_registry.py
+++ b/core/event_registry.py
@@ -3,8 +3,9 @@ import json
 from collections import defaultdict
 from datetime import datetime
 from threading import Lock
+from core.config import MITCH_ROOT
 
-REGISTRY_LOG_PATH = "/home/triad/mitch/logs/event_registry.jsonl"
+REGISTRY_LOG_PATH = os.path.join(MITCH_ROOT, "logs", "event_registry.jsonl")
 
 class EventRegistry:
     _instance = None

--- a/core/peterjones.py
+++ b/core/peterjones.py
@@ -2,9 +2,10 @@ import logging
 import os
 from datetime import datetime
 from core.event_bus import event_bus
+from core.config import MITCH_ROOT
 
 # === Paths ===
-MAIN_LOG_PATH = "/home/triad/mitch/data/mitch.log"
+MAIN_LOG_PATH = os.path.join(MITCH_ROOT, "data", "mitch.log")
 os.makedirs(os.path.dirname(MAIN_LOG_PATH), exist_ok=True)
 
 # === Primary Logger Setup (mitch.log) ===

--- a/mitch_memory_audit.py
+++ b/mitch_memory_audit.py
@@ -1,8 +1,9 @@
 import os
 import ast
 import json
+from core.config import MITCH_ROOT
 
-PROJECT_ROOT = "/home/triad/mitch"
+PROJECT_ROOT = MITCH_ROOT
 MEMORY_AUDIT_FILE = "mitch_memory_audit.txt"
 
 memory_keywords = {

--- a/modules/emotion_tracker.py
+++ b/modules/emotion_tracker.py
@@ -1,9 +1,10 @@
 import os
 import json
-datetime
+import datetime
 from core.event_bus import event_bus
+from core.config import MITCH_ROOT
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/emotion_tracker.log'
+LOG_FILE_PATH = os.path.join(MITCH_ROOT, 'logs', 'emotion_tracker.log')
 
 class EmotionTracker:
     def __init__(self):

--- a/modules/inspection_log_digester.py
+++ b/modules/inspection_log_digester.py
@@ -2,8 +2,9 @@ import json
 from pathlib import Path
 from datetime import datetime
 from core.event_bus import event_bus
+from core.config import MITCH_ROOT
 
-LOG_DIR = Path("/home/triad/mitch/logs/")
+LOG_DIR = Path(MITCH_ROOT) / "logs"
 DIGEST_FILE = LOG_DIR / "inspection_digest.json"
 MAX_BYTES_PER_LOG = 5000
 MAX_LOGS = 30

--- a/modules/module_editor.py
+++ b/modules/module_editor.py
@@ -1,7 +1,6 @@
 import os
 from core.event_bus import event_bus
-
-MITCH_ROOT = "/home/triad/mitch"
+from core.config import MITCH_ROOT
 
 # Utility to verify the path stays inside MITCH_ROOT
 def safe_path(filename):
@@ -97,7 +96,7 @@ def handle_main_append(data):
         print(f"[ModuleEditor] Failed to append to main.py: {e}")
 
 def start_module_editor():
-    print("[ModuleEditor] Online and enforcing sandbox to /home/triad/mitch")
+    print(f"[ModuleEditor] Online and enforcing sandbox to {MITCH_ROOT}")
     event_bus.subscribe("EMIT_MODULE_CREATE", handle_module_create)
     event_bus.subscribe("EMIT_MODULE_READ", handle_module_read)
     event_bus.subscribe("EMIT_MODULE_EDIT", handle_module_edit)

--- a/modules/proxmon.py
+++ b/modules/proxmon.py
@@ -9,6 +9,7 @@ import os
 from threading import Thread
 from dotenv import load_dotenv
 from core.event_bus import EventBus
+from core.config import MITCH_ROOT
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 logger = logging.getLogger("ProxMon")
@@ -29,7 +30,7 @@ class ProxMonModule:
         self.csrf_token = None
         self.ticket = None
 
-        log_dir = "/home/triad/mitch/data"
+        log_dir = os.path.join(MITCH_ROOT, "data")
         os.makedirs(log_dir, exist_ok=True)
         self.node_log_path = os.path.join(log_dir, "node_status.jsonl")
         self.vm_log_path = os.path.join(log_dir, "vm_status.jsonl")

--- a/modules/resource_monitor.py
+++ b/modules/resource_monitor.py
@@ -2,8 +2,9 @@ import os
 import json
 import datetime
 from core.event_bus import event_bus
+from core.config import MITCH_ROOT
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/resource_monitor.log'
+LOG_FILE_PATH = os.path.join(MITCH_ROOT, 'logs', 'resource_monitor.log')
 
 class ResourceMonitor:
     def __init__(self, cpu_threshold=80.0, memory_threshold=80.0, disk_threshold=90.0):

--- a/modules/resource_optimizer.py
+++ b/modules/resource_optimizer.py
@@ -2,8 +2,9 @@ import os
 import psutil
 import time
 from core.event_bus import event_bus
+from core.config import MITCH_ROOT
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/resource_optimizer.log'
+LOG_FILE_PATH = os.path.join(MITCH_ROOT, 'logs', 'resource_optimizer.log')
 
 class ResourceOptimizer:
     def __init__(self):

--- a/modules/stream_mouth.py
+++ b/modules/stream_mouth.py
@@ -11,9 +11,10 @@ import pyaudio
 from collections import defaultdict
 from core.event_bus import EventBus
 from piper import PiperVoice
+from core.config import MITCH_ROOT
 
 # === CONFIG ===
-MODEL_PATH = Path("/home/triad/mitch/modules/voice/en_GB-northern_english_male-medium.onnx")
+MODEL_PATH = Path(MITCH_ROOT) / "modules/voice/en_GB-northern_english_male-medium.onnx"
 CONFIG_PATH = MODEL_PATH.with_suffix(".onnx.json")
 CHUNK_TRIGGER_LEN = 40
 CHUNK_BREAK_CHARS = {'.', '?', '!', '\n'}

--- a/modules/task_scheduler.py
+++ b/modules/task_scheduler.py
@@ -3,8 +3,9 @@ import json
 import datetime
 import threading
 from core.event_bus import event_bus
+from core.config import MITCH_ROOT
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/task_scheduler.log'
+LOG_FILE_PATH = os.path.join(MITCH_ROOT, 'logs', 'task_scheduler.log')
 
 class TaskScheduler:
     def __init__(self):

--- a/modules/web_search.py
+++ b/modules/web_search.py
@@ -2,8 +2,9 @@ import requests
 import datetime
 import os
 from core.event_bus import event_bus
+from core.config import MITCH_ROOT
 
-LOG_PATH = '/home/triad/mitch/logs/web_search.log'
+LOG_PATH = os.path.join(MITCH_ROOT, 'logs', 'web_search.log')
 SEARCH_API = 'https://api.duckduckgo.com/'
 
 

--- a/thought.py
+++ b/thought.py
@@ -9,6 +9,7 @@ import os
 import sys
 from modules import memory
 from core.event_bus import event_bus
+from core.config import MITCH_ROOT
 
 # Fallback: load API key from mitchskeys if not already in environment
 if not os.getenv("OPENAI_API_KEY"):
@@ -27,16 +28,16 @@ client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 MODEL = "gpt-4o"
 
 THINK_INTERVAL = 4800
-MODULE_PATH = Path("/home/triad/mitch/modules/")
-THOUGHT_LOG = Path("/home/triad/mitch/logs/thoughts.log")
-CREATED_LOG = Path("/home/triad/mitch/logs/modules_created.log")
-FAIL_LOG = Path("/home/triad/mitch/logs/thought_fail.log")
-DEBUG_DUMP = Path("/home/triad/mitch/logs/raw_thought_debug.json")
-DEBUG_PROMPT_LOG = Path("/home/triad/mitch/logs/gpt_prompt_debug.txt")
-POLICY_PATH = Path("/home/triad/mitch/config/module_policy.json")
-FEEDBACK_LOG = Path("/home/triad/mitch/logs/echo_feedback.jsonl")
-INSPECTION_DIGEST_PATH = Path("/home/triad/mitch/logs/inspection_digest.json")
-AUDIT_PATH = Path("/home/triad/mitch/data/mitch_audit_report.txt")
+MODULE_PATH = Path(MITCH_ROOT) / "modules"
+THOUGHT_LOG = Path(MITCH_ROOT) / "logs/thoughts.log"
+CREATED_LOG = Path(MITCH_ROOT) / "logs/modules_created.log"
+FAIL_LOG = Path(MITCH_ROOT) / "logs/thought_fail.log"
+DEBUG_DUMP = Path(MITCH_ROOT) / "logs/raw_thought_debug.json"
+DEBUG_PROMPT_LOG = Path(MITCH_ROOT) / "logs/gpt_prompt_debug.txt"
+POLICY_PATH = Path(MITCH_ROOT) / "config/module_policy.json"
+FEEDBACK_LOG = Path(MITCH_ROOT) / "logs/echo_feedback.jsonl"
+INSPECTION_DIGEST_PATH = Path(MITCH_ROOT) / "logs/inspection_digest.json"
+AUDIT_PATH = Path(MITCH_ROOT) / "data/mitch_audit_report.txt"
 
 IDENTITY = """You are Echo - a GPT-based autonomous logic engine embedded inside MITCH.
 You can write and deploy new Python modules to /home/triad/mitch/modules/.


### PR DESCRIPTION
## Summary
- add `core/config.py` for MITCH_ROOT configuration
- use `MITCH_ROOT` instead of hardcoded `/home/triad/mitch` paths
- update logging and module paths accordingly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420e11a174832382a8fc11e9232a67