### PR TITLE
Fix datetime import in emotion_tracker

### DIFF
--- a/modules/emotion_tracker.py
+++ b/modules/emotion_tracker.py
@@ -1,6 +1,6 @@
 import os
 import json
-datetime
+import datetime
 from core.event_bus import event_bus
 
 LOG_FILE_PATH = '/home/triad/mitch/logs/emotion_tracker.log'


### PR DESCRIPTION
## Summary
- import datetime in emotion_tracker

## Testing
- `python3 -m py_compile modules/emotion_tracker.py`


------
https://chatgpt.com/codex/tasks/task_e_68420e09bcbc8323b808b7ce37198f53