### PR TITLE
Use event_bus singleton in proxmon

### DIFF
--- a/modules/proxmon.py
+++ b/modules/proxmon.py
@@ -8,7 +8,7 @@ import json
 import os
 from threading import Thread
 from dotenv import load_dotenv
-from core.event_bus import EventBus
+from core.event_bus import event_bus
 from core.config import MITCH_ROOT
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -16,7 +16,6 @@ logger = logging.getLogger("ProxMon")
 
 # Load secrets
 load_dotenv("mitchskeys")
-event_bus = EventBus()
 
 class ProxMonModule:
     def __init__(self, event_bus):


### PR DESCRIPTION
## Summary
- import the shared `event_bus` instead of `EventBus`
- drop creation of a new `EventBus` instance in `proxmon`

## Testing
- `git diff HEAD~1 HEAD -U0`

------
https://chatgpt.com/codex/tasks/task_e_684213a8a23883238f7d0b93a37a6675