### PR TITLE
Add stoppable loop for ResourceOptimizer

### DIFF
--- a/main.py
+++ b/main.py
@@ -86,6 +86,7 @@ def main():
             pass
     except KeyboardInterrupt:
         print("\n🛑 MITCH shutdown signal received.")
+        event_bus.emit("SHUTDOWN")
 
         for hook in shutdown_hooks:
             try:

--- a/modules/resource_optimizer.py
+++ b/modules/resource_optimizer.py
@@ -11,6 +11,7 @@ class ResourceOptimizer:
         self.cpu_threshold = 80  # in percentage
         self.memory_threshold = 80  # in percentage
         self.disk_threshold = 80  # in percentage
+        self.running = True
 
     def log(self, message):
         with open(LOG_FILE_PATH, 'a') as log_file:
@@ -47,15 +48,23 @@ class ResourceOptimizer:
         event_bus.subscribe('high_cpu_usage', self.handle_high_cpu_usage)
         event_bus.subscribe('high_memory_usage', self.handle_high_memory_usage)
         event_bus.subscribe('high_disk_usage', self.handle_high_disk_usage)
+        self.running = True
 
         # Continuously check resources
-        while True:
+        while self.running:
             self.check_resources()
-            
+
             # Sleep for a predefined interval to avoid excessive resource usage
-            time.sleep(10)
+            for _ in range(10):
+                if not self.running:
+                    break
+                time.sleep(1)
+
+    def shutdown(self, _=None):
+        self.running = False
 
 
 def start_module(event_bus):
     optimizer = ResourceOptimizer()
+    event_bus.subscribe('SHUTDOWN', optimizer.shutdown)
     optimizer.start()


### PR DESCRIPTION
## Summary
- add a running flag to `ResourceOptimizer`
- provide a shutdown method and listen for `SHUTDOWN`
- emit `SHUTDOWN` event in `main.py` so modules can stop cleanly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684213ba68fc8323b10f537cc65c931b