### PR TITLE
Centralize logging to innermono.log

### DIFF
--- a/core/peterjones.py
+++ b/core/peterjones.py
@@ -3,11 +3,11 @@ import os
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
 
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 from core.config import MITCH_ROOT
 
 # === Paths ===
-MAIN_LOG_PATH = os.path.join(MITCH_ROOT, "data", "mitch.log")
+MAIN_LOG_PATH = INNERMONO_PATH
 os.makedirs(os.path.dirname(MAIN_LOG_PATH), exist_ok=True)
 
 # === Formatter ===

--- a/modules/active_learning.py
+++ b/modules/active_learning.py
@@ -1,9 +1,9 @@
 import os
 import json
 from datetime import datetime
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/active_learning.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class ActiveLearning:
     def __init__(self):

--- a/modules/activity_recognition.py
+++ b/modules/activity_recognition.py
@@ -1,9 +1,9 @@
 import os
 import json
 from datetime import datetime
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/activity_recognition.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class ActivityRecognition:
     def __init__(self):

--- a/modules/adaptive_energy_saver.py
+++ b/modules/adaptive_energy_saver.py
@@ -1,8 +1,8 @@
 import os
 import datetime
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/adaptive_energy_saver.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class AdaptiveEnergySaver:
     def __init__(self):

--- a/modules/collaborative_task_manager.py
+++ b/modules/collaborative_task_manager.py
@@ -1,9 +1,9 @@
 import os
 import json
 from datetime import datetime
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/collaborative_task_manager.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class CollaborativeTaskManager:
     def __init__(self):

--- a/modules/conversation_flow_analyzer.py
+++ b/modules/conversation_flow_analyzer.py
@@ -1,9 +1,9 @@
 import os
 import json
 import datetime
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/conversation_flow_analyzer.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class ConversationFlowAnalyzer:
     def __init__(self):

--- a/modules/daily_summary_generator.py
+++ b/modules/daily_summary_generator.py
@@ -1,9 +1,9 @@
 import os
 import json
 import datetime
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/daily_summary.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class DailySummaryGenerator:
     def __init__(self):

--- a/modules/decision_audit.py
+++ b/modules/decision_audit.py
@@ -1,9 +1,9 @@
 import os
 import json
 from datetime import datetime
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/decision_audit.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class DecisionAudit:
     def __init__(self):

--- a/modules/dynamic_task_optimizer.py
+++ b/modules/dynamic_task_optimizer.py
@@ -1,9 +1,9 @@
 import os
 import json
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 from datetime import datetime
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/dynamic_task_optimizer.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class DynamicTaskOptimizer:
     def __init__(self):

--- a/modules/energy_efficiency_optimizer.py
+++ b/modules/energy_efficiency_optimizer.py
@@ -1,9 +1,9 @@
 import os
 import json
 import datetime
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/energy_efficiency_optimizer.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class EnergyEfficiencyOptimizer:
     def __init__(self):

--- a/modules/focus_mode.py
+++ b/modules/focus_mode.py
@@ -1,9 +1,9 @@
 import os
 import json
 import datetime
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/focus_mode.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class FocusMode:
     def __init__(self):

--- a/modules/habit_analyzer.py
+++ b/modules/habit_analyzer.py
@@ -1,9 +1,9 @@
 import os
 import json
 from datetime import datetime
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/habit_analyzer.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class HabitAnalyzer:
     def __init__(self):

--- a/modules/habit_reinforcer.py
+++ b/modules/habit_reinforcer.py
@@ -1,9 +1,9 @@
 import os
 import json
 from datetime import datetime, timedelta
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/habit_reinforcer.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class HabitReinforcer:
     def __init__(self):

--- a/modules/habit_suggester.py
+++ b/modules/habit_suggester.py
@@ -1,9 +1,9 @@
 import os
 import json
 from datetime import datetime
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/habit_suggester.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class HabitSuggester:
     def __init__(self):

--- a/modules/habit_tracker.py
+++ b/modules/habit_tracker.py
@@ -1,9 +1,9 @@
 import os
 import json
 import datetime
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/habit_tracker.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class HabitTracker:
     def __init__(self):

--- a/modules/interpreter.py
+++ b/modules/interpreter.py
@@ -1,5 +1,5 @@
 import re
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 from core.peterjones import get_logger
 from difflib import SequenceMatcher
 
@@ -78,7 +78,7 @@ registered_intents = {
     "keywords": ["read", "show", "check", "display"],
     "objects": ["log", "logfile", "modules_created", "created modules", "log file"],
     "handler": lambda text: event_bus.emit("EMIT_READ_LOG", {
-        "path": "/home/triad/mitch/logs/modules_created.log"
+        "path": INNERMONO_PATH
     })
     },
 }

--- a/modules/mindfulness_reminder.py
+++ b/modules/mindfulness_reminder.py
@@ -1,7 +1,7 @@
 import datetime
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/mindfulness_reminder.log'
+LOG_FILE_PATH = INNERMONO_PATH
 REMINDER_INTERVAL = 3600  # seconds (1 hour)
 
 class MindfulnessReminder:

--- a/modules/network_status_monitor.py
+++ b/modules/network_status_monitor.py
@@ -2,9 +2,9 @@ import os
 import json
 import time
 import psutil
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/network_status.log'
+LOG_FILE_PATH = INNERMONO_PATH
 ALERT_THRESHOLD = 80.0  # Percentage of bandwidth usage that triggers an alert
 CHECK_INTERVAL = 60  # Time in seconds between checks
 

--- a/modules/pattern_recognition.py
+++ b/modules/pattern_recognition.py
@@ -1,9 +1,9 @@
 import os
 import json
 from collections import defaultdict
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/pattern_recognition.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class PatternRecognition:
     def __init__(self):

--- a/modules/stress_level_analyzer.py
+++ b/modules/stress_level_analyzer.py
@@ -1,9 +1,9 @@
 import os
 import json
 import datetime
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/stress_level_analyzer.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class StressLevelAnalyzer:
     def __init__(self):

--- a/modules/system_health_checker.py
+++ b/modules/system_health_checker.py
@@ -1,9 +1,9 @@
 import time
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 import os
 import json
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/system_health_checker.log'
+LOG_FILE_PATH = INNERMONO_PATH
 CHECK_INTERVAL = 300  # Check every 5 minutes
 
 class SystemHealthChecker:

--- a/modules/task_dependency_manager.py
+++ b/modules/task_dependency_manager.py
@@ -1,8 +1,8 @@
 import os
 import json
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/task_dependency_manager.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class TaskDependencyManager:
     def __init__(self):

--- a/modules/time_management_assistant.py
+++ b/modules/time_management_assistant.py
@@ -1,8 +1,8 @@
 import datetime
 import json
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/time_management_assistant.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class TimeManagementAssistant:
     def __init__(self):

--- a/modules/time_zone_adjuster.py
+++ b/modules/time_zone_adjuster.py
@@ -1,9 +1,9 @@
 import os
 import json
 from datetime import datetime, timezone, timedelta
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/time_zone_adjuster.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class TimeZoneAdjuster:
     def __init__(self):

--- a/modules/user_behavior_predictor.py
+++ b/modules/user_behavior_predictor.py
@@ -1,8 +1,8 @@
 import json
 import datetime
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/user_behavior_predictor.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class UserBehaviorPredictor:
     def __init__(self):

--- a/modules/user_engagement_tracker.py
+++ b/modules/user_engagement_tracker.py
@@ -1,9 +1,9 @@
 import os
 import json
 import datetime
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/user_engagement_tracker.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class UserEngagementTracker:
     def __init__(self):

--- a/modules/user_interaction_analyzer.py
+++ b/modules/user_interaction_analyzer.py
@@ -1,9 +1,9 @@
 import os
 import json
 from datetime import datetime
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/user_interaction_analyzer.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class UserInteractionAnalyzer:
     def __init__(self):

--- a/modules/user_preference_analyzer.py
+++ b/modules/user_preference_analyzer.py
@@ -1,8 +1,8 @@
 import os
 import json
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 
-LOG_FILE_PATH = '/home/triad/mitch/logs/user_preference_analyzer.log'
+LOG_FILE_PATH = INNERMONO_PATH
 
 class UserPreferenceAnalyzer:
     def __init__(self):

--- a/thought.py
+++ b/thought.py
@@ -8,7 +8,7 @@ from openai import OpenAI
 import os
 import sys
 from modules import memory
-from core.event_bus import event_bus
+from core.event_bus import event_bus, INNERMONO_PATH
 from core.config import MITCH_ROOT
 
 # Fallback: load API key from mitchskeys if not already in environment
@@ -29,13 +29,13 @@ MODEL = "gpt-4o"
 
 THINK_INTERVAL = 4800
 MODULE_PATH = Path(MITCH_ROOT) / "modules"
-THOUGHT_LOG = Path(MITCH_ROOT) / "logs/thoughts.log"
-CREATED_LOG = Path(MITCH_ROOT) / "logs/modules_created.log"
-FAIL_LOG = Path(MITCH_ROOT) / "logs/thought_fail.log"
-DEBUG_DUMP = Path(MITCH_ROOT) / "logs/raw_thought_debug.json"
-DEBUG_PROMPT_LOG = Path(MITCH_ROOT) / "logs/gpt_prompt_debug.txt"
+THOUGHT_LOG = Path(INNERMONO_PATH)
+CREATED_LOG = Path(INNERMONO_PATH)
+FAIL_LOG = Path(INNERMONO_PATH)
+DEBUG_DUMP = Path(INNERMONO_PATH)
+DEBUG_PROMPT_LOG = Path(INNERMONO_PATH)
 POLICY_PATH = Path(MITCH_ROOT) / "config/module_policy.json"
-FEEDBACK_LOG = Path(MITCH_ROOT) / "logs/echo_feedback.jsonl"
+FEEDBACK_LOG = Path(INNERMONO_PATH)
 INSPECTION_DIGEST_PATH = Path(MITCH_ROOT) / "logs/inspection_digest.json"
 AUDIT_PATH = Path(MITCH_ROOT) / "data/mitch_audit_report.txt"
 
@@ -63,8 +63,8 @@ def list_existing_modules():
     if not CREATED_LOG.exists():
         return []
     with CREATED_LOG.open("r", encoding="utf-8") as f:
-        lines = f.readlines()
-    return [line.split("Module Created: ")[1].split(" - ")[0] for line in lines if "Module Created:" in line]
+        lines = [line for line in f if "Module Created:" in line]
+    return [line.split("Module Created: ")[1].split(" - ")[0] for line in lines]
 
 def load_policy():
     if POLICY_PATH.exists():
@@ -78,8 +78,9 @@ def load_policy():
 def load_recent_feedback(limit=5):
     if FEEDBACK_LOG.exists():
         with FEEDBACK_LOG.open("r", encoding="utf-8") as f:
-            lines = f.readlines()[-limit:]
-            return [json.loads(line.strip()) for line in lines if line.strip()]
+            lines = [line for line in f if line.strip().startswith("{")]
+        lines = lines[-limit:]
+        return [json.loads(line.strip()) for line in lines]
     return []
 
 def build_prompt_template():


### PR DESCRIPTION
## Summary
- update `core.peterjones` to log to `innermono.log`
- route module logs to the same file via `INNERMONO_PATH`
- adjust interpreter to read the unified log
- consolidate thought logging into `innermono.log`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849d934bf1c83238950bcc7ed5ff618