### PR TITLE
Fix EMIT_SPEAK handling and imports

### DIFF
--- a/modules/active_reminder.py
+++ b/modules/active_reminder.py
@@ -29,14 +29,20 @@ class ActiveReminder:
         if reminder_time and task_description:
             self.reminders.append({'reminder_time': reminder_time, 'task_description': task_description})
             self.save_reminders()
-            event_bus.emit('EMIT_SPEAK', f"Reminder set for {task_description} at {reminder_time}.")
+            event_bus.emit('EMIT_SPEAK', {
+                'text': f"Reminder set for {task_description} at {reminder_time}.",
+                'token': str(time.time())
+            })
 
     def check_reminders(self):
         current_time = datetime.datetime.now().strftime('%Y-%m-%d %H:%M')
         reminders_to_remove = []
         for reminder in self.reminders:
             if reminder['reminder_time'] <= current_time:
-                event_bus.emit('EMIT_SPEAK', f"Reminder: {reminder['task_description']}.")
+                event_bus.emit('EMIT_SPEAK', {
+                    'text': f"Reminder: {reminder['task_description']}.",
+                    'token': str(time.time())
+                })
                 reminders_to_remove.append(reminder)
         self.reminders = [reminder for reminder in self.reminders if reminder not in reminders_to_remove]
         if reminders_to_remove:
@@ -54,5 +60,8 @@ class ActiveReminder:
 def start_module(event_bus):
     active_reminder = ActiveReminder()
     event_bus.subscribe('TASK_SCHEDULED', active_reminder.handle_task_event)
-    event_bus.emit('EMIT_SPEAK', 'Active Reminder module started and listening for task scheduling events.')
+    event_bus.emit('EMIT_SPEAK', {
+        'text': 'Active Reminder module started and listening for task scheduling events.',
+        'token': str(time.time())
+    })
     active_reminder.run()

--- a/modules/adaptive_energy_saver.py
+++ b/modules/adaptive_energy_saver.py
@@ -1,5 +1,6 @@
 import os
 import datetime
+import time
 from core.event_bus import event_bus, INNERMONO_PATH
 
 LOG_FILE_PATH = INNERMONO_PATH

--- a/modules/habit_reinforcer.py
+++ b/modules/habit_reinforcer.py
@@ -1,5 +1,6 @@
 import os
 import json
+import time
 from datetime import datetime, timedelta
 from core.event_bus import event_bus, INNERMONO_PATH
 
@@ -46,7 +47,10 @@ class HabitReinforcer:
     def _emit_feedback(self, habit_name):
         """Emit positive feedback for habit completion."""
         feedback_message = f"Great job on completing your habit: {habit_name} today! Keep it up!"
-        event_bus.emit('EMIT_SPEAK', {'message': feedback_message})
+        event_bus.emit('EMIT_SPEAK', {
+            'text': feedback_message,
+            'token': str(time.time())
+        })
 
 
 def start_module(event_bus):

--- a/modules/interpreter.py
+++ b/modules/interpreter.py
@@ -1,4 +1,5 @@
 import re
+import time
 from core.event_bus import event_bus, INNERMONO_PATH
 from core.peterjones import get_logger
 from difflib import SequenceMatcher
@@ -56,7 +57,10 @@ registered_intents = {
         "handler": lambda text: (
             lambda match: (
                 event_bus.emit("EMIT_MODULE_EDIT", {"filename": f"modules/{match.group(1)}.py", "content": match.group(2)}),
-                event_bus.emit("EMIT_SPEAK", {"text": f"Module {match.group(1)} has been updated."})
+                event_bus.emit("EMIT_SPEAK", {
+                    "text": f"Module {match.group(1)} has been updated.",
+                    "token": str(time.time())
+                })
             ) if (match := re.match(r"edit module (\w+)\s+(.*)", text)) else None
         )(text)
     },

--- a/modules/mindfulness_reminder.py
+++ b/modules/mindfulness_reminder.py
@@ -1,4 +1,5 @@
 import datetime
+import time
 from core.event_bus import event_bus, INNERMONO_PATH
 
 LOG_FILE_PATH = INNERMONO_PATH
@@ -21,7 +22,10 @@ class MindfulnessReminder:
 
     def emit_mindfulness_reminder(self):
         reminder_message = "It's time to take a short break and practice mindfulness!"
-        event_bus.emit('EMIT_SPEAK', {'message': reminder_message})
+        event_bus.emit('EMIT_SPEAK', {
+            'text': reminder_message,
+            'token': str(time.time())
+        })
         self.log(f"Mindfulness reminder emitted: {reminder_message}")
 
 

--- a/modules/time_management_assistant.py
+++ b/modules/time_management_assistant.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import time
 from core.event_bus import event_bus, INNERMONO_PATH
 
 LOG_FILE_PATH = INNERMONO_PATH
@@ -24,7 +25,10 @@ class TimeManagementAssistant:
 
     def _notify_user(self, task):
         """Notify the user about a task."""
-        event_bus.emit('EMIT_SPEAK', {'message': f'Reminder: {task}'})
+        event_bus.emit('EMIT_SPEAK', {
+            'text': f'Reminder: {task}',
+            'token': str(time.time())
+        })
         self._log(f"Notified user about task: {task}")
 
     def analyze_time_usage(self, event_data):
@@ -32,7 +36,10 @@ class TimeManagementAssistant:
         # Assume event_data contains time usage patterns
         time_usage = event_data.get('time_usage')
         suggestions = self._generate_suggestions(time_usage)
-        event_bus.emit('EMIT_SPEAK', {'message': f'Time Management Tips: {suggestions}'})
+        event_bus.emit('EMIT_SPEAK', {
+            'text': f'Time Management Tips: {suggestions}',
+            'token': str(time.time())
+        })
         self._log(f"Time usage analyzed. Suggestions: {suggestions}")
 
     def _generate_suggestions(self, time_usage):


### PR DESCRIPTION
## Summary
- add `time` import for `adaptive_energy_saver`
- emit `EMIT_SPEAK` with structured data and tokens
- ensure interpreter emits tokenized `EMIT_SPEAK`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: build wheel for pyaudio)*

------
https://chatgpt.com/codex/tasks/task_e_6849e02faa708323a687d97af7f5ef86