### PR TITLE
Improve OpenAI key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ MITCH is a modular Python framework that coordinates several threads to create a
 
 1. **Set environment variables**
    - `OPENAI_API_KEY` – OpenAI API key used by the GPT components.
+     If this variable isn't set, some modules will try to read the key from a
+     file named `mitchskeys` in the project root (format: `OPENAI_API_KEY=...`).
    - `MITCH_DEBUG` *(optional)* – set to `true` for verbose logging.
    - `MITCH_SPEAKER_DEBUG` *(optional)* – enables additional speaker logs.
    - `PROXMOX_PASSWORD` *(optional)* – required when using the `proxmon` module.

--- a/modules/gpt_handler.py
+++ b/modules/gpt_handler.py
@@ -4,6 +4,7 @@ import json
 import re
 from openai import OpenAI
 from pathlib import Path
+import os
 from core.event_bus import event_bus
 from core.peterjones import get_logger
 from modules import memory, persona
@@ -16,6 +17,18 @@ except ImportError:
     HAS_OLLAMA = False
 
 logger = get_logger("gptv2")
+
+if not os.getenv("OPENAI_API_KEY"):
+    key_path = Path(__file__).resolve().parent.parent / "mitchskeys"
+    if key_path.exists():
+        for line in key_path.read_text(encoding="utf-8").splitlines():
+            if "OPENAI_API_KEY=" in line:
+                os.environ["OPENAI_API_KEY"] = line.split("=", 1)[1].strip().strip('"').strip("'")
+                break
+
+if not os.getenv("OPENAI_API_KEY"):
+    logger.warning("OPENAI_API_KEY not found; GPT features will fail unless set.")
+
 client = OpenAI()
 
 SYSTEM_PROMPT = persona.build_system_prompt()

--- a/modules/time_management_assistant.py
+++ b/modules/time_management_assistant.py
@@ -48,7 +48,7 @@ class TimeManagementAssistant:
     def report_time_spent(self):
         report = 'Time Spent Report:\n'
         for task, data in self.time_spent.items():
-            report += f'- {task}: {data['total']:.2f} minutes\n'
+            report += f"- {task}: {data['total']:.2f} minutes\n"
         event_bus.emit('EMIT_SPEAK', {'message': report})
         self.log_action('Time spent report emitted.')
 

--- a/modules/vision_ai.py
+++ b/modules/vision_ai.py
@@ -2,12 +2,24 @@
 
 import openai
 import os
+from pathlib import Path
 from dotenv import load_dotenv
 from modules.vision import VisionModule
 from core.peterjones import get_logger
 
 # Load secrets
 load_dotenv(dotenv_path="mitchskeys")
+
+if not os.getenv("OPENAI_API_KEY"):
+    key_path = Path(__file__).resolve().parent.parent / "mitchskeys"
+    if key_path.exists():
+        for line in key_path.read_text(encoding="utf-8").splitlines():
+            if "OPENAI_API_KEY=" in line:
+                os.environ["OPENAI_API_KEY"] = line.split("=", 1)[1].strip().strip('"').strip("'")
+                break
+
+if not os.getenv("OPENAI_API_KEY"):
+    print("[VisionAI] Warning: OPENAI_API_KEY not set; vision features may fail.")
 
 # Initialize OpenAI client
 client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))


### PR DESCRIPTION
## Summary
- load `OPENAI_API_KEY` from a `mitchskeys` file when not set
- warn when the key is missing in GPT and Vision modules
- fix a string quoting bug in `time_management_assistant`
- document the mitchskeys fallback in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686816d624a88323aa8a27f987d31068