### PR TITLE
feat: support dynamic intent registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,28 @@ Install Python requirements (if a `requirements.txt` is present) with:
 pip install -r requirements.txt
 ```
 
+## Registering intents
+
+Modules can contribute new phrases by emitting a `REGISTER_INTENT` event when they
+start up. The event payload must include:
+
+- `intent` – unique name for the intent.
+- `keywords` – list of words used for matching.
+- `objects` – optional secondary words.
+- `handler` – callable invoked with the original text when the intent matches.
+
+Example:
+
+```python
+event_bus.emit("REGISTER_INTENT", {
+    "intent": "get_weather",
+    "keywords": ["weather", "forecast"],
+    "objects": ["in", "at", "for"],
+    "handler": lambda text: event_bus.emit("GET_WEATHER", {"location": "newcastle"})
+})
+```
+
+The interpreter stores the keywords and objects in
+`data/injections/intents.json` so newly registered intents are immediately
+available for matching.
+

--- a/modules/flight_tracker.py
+++ b/modules/flight_tracker.py
@@ -6,6 +6,7 @@ from core.event_bus import event_bus
 from core.config import MITCH_ROOT
 from core.peterjones import get_logger
 from core.keys_loader import load_keys  # <-- add this
+from modules.interpreter import extract_region_for_flights
 
 logger = get_logger("flight_tracker")
 
@@ -57,3 +58,27 @@ def _get_token() -> str | None:
         logger.warning(f"[opensky-oauth] token fetch failed: {e}")
 
     return None
+
+
+def start_module(event_bus):
+    logger.info("Flight tracker module started")
+    event_bus.emit(
+        "REGISTER_INTENT",
+        {
+            "intent": "track_flights",
+            "keywords": [
+                "track",
+                "planes",
+                "plane",
+                "flights",
+                "flight",
+                "aircraft",
+                "traffic",
+            ],
+            "objects": ["over", "above", "near", "in", "around"],
+            "handler": lambda text: event_bus.emit(
+                "EMIT_TRACK_FLIGHTS",
+                {"region": extract_region_for_flights(text) or "newcastle"},
+            ),
+        },
+    )

--- a/modules/weather_fetcher.py
+++ b/modules/weather_fetcher.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from core.event_bus import event_bus
 from core.peterjones import get_logger
 from core.config import MITCH_ROOT
+from modules.interpreter import extract_location_from_text
 
 logger = get_logger("weather_fetcher")
 
@@ -112,3 +113,11 @@ def fetch_weather(location="newcastle"):
 def start_module(event_bus):
     logger.info("Weather module started")
     event_bus.subscribe("GET_WEATHER", lambda data: fetch_weather(data.get("location", "newcastle")))
+    event_bus.emit("REGISTER_INTENT", {
+        "intent": "get_weather",
+        "keywords": ["weather", "forecast", "rain", "temperature", "conditions"],
+        "objects": ["today", "outside", "like", "right now", "tomorrow", "in", "at", "for"],
+        "handler": lambda text: event_bus.emit(
+            "GET_WEATHER", {"location": extract_location_from_text(text) or "newcastle"}
+        ),
+    })


### PR DESCRIPTION
## Summary
- allow interpreter to accept `REGISTER_INTENT` events and persist new intents
- emit registration events from weather and flight tracker modules
- document `REGISTER_INTENT` payload for future modules

## Testing
- `python -m pytest`
- `python -m py_compile modules/interpreter.py modules/weather_fetcher.py modules/flight_tracker.py`


------
https://chatgpt.com/codex/tasks/task_e_68ace5693208832383cfd5df2ea63d35