### PR TITLE
Remove mitchskeys credential fallbacks

### DIFF
--- a/modules/automated_flight_tracker.py
+++ b/modules/automated_flight_tracker.py
@@ -8,7 +8,6 @@ from datetime import datetime, timezone
 from typing import Dict, Any, List, Tuple
 import re
 import requests
-from pathlib import Path
 
 from core.peterjones import get_logger
 from core.config import MITCH_ROOT
@@ -53,17 +52,6 @@ def _get_token() -> str | None:
     now = time.time()
     if _token_cache["value"] and now < _token_cache["expires"]:
         return _token_cache["value"]
-
-    # Load API keys from local file if env vars not set
-    key_path = Path(__file__).resolve().parent.parent / "mitchskeys"
-    if key_path.exists():
-        for line in key_path.read_text(encoding="utf-8").splitlines():
-            if "=" in line:
-                key, val = line.split("=", 1)
-                key = key.strip()
-                val = val.strip().strip('"').strip("'")
-                if key and not os.getenv(key):
-                    os.environ[key] = val
 
     client_id = os.getenv("OPENSKY_CLIENT_ID")
     client_secret = os.getenv("OPENSKY_CLIENT_SECRET")

--- a/modules/gpt_handler.py
+++ b/modules/gpt_handler.py
@@ -17,17 +17,6 @@ except ImportError:
 
 logger = get_logger("gptv2")
 
-# Load API key from local file if env var not set
-if not os.getenv("OPENAI_API_KEY"):
-    key_path = Path(__file__).resolve().parent.parent / "mitchskeys"
-    if key_path.exists():
-        for line in key_path.read_text(encoding="utf-8").splitlines():
-            if "OPENAI_API_KEY=" in line:
-                os.environ["OPENAI_API_KEY"] = (
-                    line.split("=", 1)[1].strip().strip('"').strip("'")
-                )
-                break
-
 if not os.getenv("OPENAI_API_KEY"):
     logger.warning("OPENAI_API_KEY not found; GPT features will fail unless set.")
 

--- a/modules/proxmon.py
+++ b/modules/proxmon.py
@@ -4,16 +4,13 @@ import os
 import requests
 import urllib3
 from threading import Thread
-from dotenv import load_dotenv
+from core.keys_loader import load_keys  # noqa: F401
 from core.event_bus import event_bus
 from core.config import MITCH_ROOT
 from core.peterjones import get_logger
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 logger = get_logger("proxmon")
-
-# Load secrets
-load_dotenv("mitchskeys")
 
 class ProxMonModule:
     def __init__(self, event_bus):

--- a/modules/vision_ai.py
+++ b/modules/vision_ai.py
@@ -2,21 +2,8 @@
 
 import openai
 import os
-from pathlib import Path
-from dotenv import load_dotenv
 from modules.vision import VisionModule
 from core.peterjones import get_logger
-
-# Load secrets
-load_dotenv(dotenv_path="mitchskeys")
-
-if not os.getenv("OPENAI_API_KEY"):
-    key_path = Path(__file__).resolve().parent.parent / "mitchskeys"
-    if key_path.exists():
-        for line in key_path.read_text(encoding="utf-8").splitlines():
-            if "OPENAI_API_KEY=" in line:
-                os.environ["OPENAI_API_KEY"] = line.split("=", 1)[1].strip().strip('"').strip("'")
-                break
 
 if not os.getenv("OPENAI_API_KEY"):
     print("[VisionAI] Warning: OPENAI_API_KEY not set; vision features may fail.")

--- a/thought.py
+++ b/thought.py
@@ -11,18 +11,8 @@ from modules import memory
 from core.event_bus import event_bus
 from core.config import MITCH_ROOT
 
-# Fallback: load API key from mitchskeys if not already in environment
 if not os.getenv("OPENAI_API_KEY"):
-    mitchskeys_path = Path(__file__).parent / "mitchskeys"
-    if mitchskeys_path.exists():
-        for line in mitchskeys_path.read_text(encoding="utf-8").replace("\r", "").split("\n"):
-            if "OPENAI_API_KEY=" in line:
-                key = line.split("=", 1)[1].strip().strip('"').strip("'")
-                os.environ["OPENAI_API_KEY"] = key
-                break
-
-if not os.getenv("OPENAI_API_KEY"):
-    raise EnvironmentError("OPENAI_API_KEY is not set. Please source mitchskeys or export the key.")
+    raise EnvironmentError("OPENAI_API_KEY is not set in the environment.")
 
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 MODEL = "gpt-4o"


### PR DESCRIPTION
## Summary
- load OpenSky credentials only from environment in automated_flight_tracker
- rely on OPENAI_API_KEY env var for GPT and Vision modules
- swap proxmon to load_keys import instead of dotenv
- enforce OPENAI_API_KEY presence in thought.py

## Testing
- `pytest`
- `python -m py_compile modules/automated_flight_tracker.py modules/gpt_handler.py modules/proxmon.py modules/vision_ai.py thought.py`


------
https://chatgpt.com/codex/tasks/task_e_68ace55612e483239a84c32086454214